### PR TITLE
Switch to the PHP Webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Grand Tour - PHP
 
-A set of example applications that will add word/definition pairs to a database running on Compose.
+A set of example applications that will add word/definition pairs to a database running on Compose.  Designed for PHP 7 (but will probably work on outdated PHP versions, e.g. PHP 5).
 
 ## Running the Example
 
@@ -10,6 +10,6 @@ To run from the command-line:
 * Navigate to the example-<_db_> directory
 * Rename the file `example-<_db_>/env.template.php` to `example-<_db_>/env.php`
 * In the file `example-<_db_>/env.php`, change the connection variables to match those of your Compose database instance.
-* And then in your browser: `http://localhost/php/example-<_db_>/templates/index.html`
-
-The application will be served on your localhost and can be opened in a browser.
+* Start the webserver with `php -S localhost:8080`
+*
+The application will be served on http://localhost:8080 and can be opened in a browser.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 
 A set of example applications that will add word/definition pairs to a database running on Compose.
 
-This repo contains the apps written in PHP 5.6.30.
-
 ## Running the Example
 
 To run from the command-line:
 
-* Make sure you have a web server running on your computer that can execute PHP 5.5+ and has the appropriate driver installed for the database you are using
 * Clone this repo to the root of your web server's document directory
 * Navigate to the example-<_db_> directory
 * Rename the file `example-<_db_>/env.template.php` to `example-<_db_>/env.php`

--- a/example/example.php
+++ b/example/example.php
@@ -1,32 +1,28 @@
 <?php
 
-if (session_status()==1) {
-  session_start(); 
+if(session_status() == PHP_SESSION_NONE) {
+    session_start(); 
+}
+
+$words = [];
+if(isset($_SESSION['items'])) {
+    $words = $_SESSION['items'];
+} else {
+    $_SESSION['items'] = [];
 }
 
 if ($_SERVER['REQUEST_METHOD'] == 'GET') {
-  header('Content-type: application/json');
-  if (!isset($_SESSION['items'])) {
-    echo '{"items":[]}';
-  } else {
-    echo '{"items":',json_encode($_SESSION['items']),'}';
-  }
+    header('Content-type: application/json');
+    echo json_encode($words);
+} else if ($_SERVER['REQUEST_METHOD'] == 'PUT') {
+    parse_str(file_get_contents("php://input"), $put_vars);
+    if (isset($put_vars['word'])) {
+        $item = array(
+            "_id" => (date(DateTime::RFC2822)),
+            "word" => $put_vars['word'], 
+            "definition" => $put_vars['definition']
+        );
+        array_push($_SESSION['items'], $item);
+    }
 }
 
-if ($_SERVER['REQUEST_METHOD'] == 'PUT') {
-  if (!isset($_SESSION['items'])) $_SESSION['items'] = array();
-  
-  parse_str(file_get_contents("php://input"), $put_vars);
-  if (isset($put_vars['word'])) {
-    $word = $put_vars['word'];
-    $defin = $put_vars['definition'];
-    $item = array(
-      "word" => $word, 
-      "definition" => $defin
-    );
-    array_push($_SESSION['items'], $item);
-    header('Content-type: text/plain');
-    echo 'added word ',$_SESSION['items'][0]['word'],' and definition ',$_SESSION['items'][0]['definition'],' to session';
-  }
-}
-?>

--- a/example/index.php
+++ b/example/index.php
@@ -1,0 +1,9 @@
+<?php
+
+// working with /words?
+if($_SERVER['REQUEST_URI'] == "/words") {
+    require "example.php";
+} else {
+    // show the web page
+    require "templates/index.html";
+}

--- a/example/static/main.js
+++ b/example/static/main.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
   function reload() {
     $('.hidden').fadeOut();
     $('displayOutput').empty();
-    $.getJSON( '/words').done(function(data) {
+    $.getJSON( 'words').done(function(data) {
       console.log("showing", data);
       var rendered = "<ul>";
       if(data.length) {
@@ -21,7 +21,7 @@ $(document).ready(function() {
   $('#add-word').submit(function(e) {
     e.preventDefault();
     $.ajax({
-      url: '/words',
+      url: 'words',
       type: 'PUT',
       data: $(this).serialize(),
       success: function(data) {

--- a/example/static/main.js
+++ b/example/static/main.js
@@ -3,12 +3,14 @@ $(document).ready(function() {
   function reload() {
     $('.hidden').fadeOut();
     $('displayOutput').empty();
-    $.getJSON( '../example').done(function(data) {
+    $.getJSON( '/words').done(function(data) {
       console.log("showing", data);
       var rendered = "<ul>";
-      data.items.forEach(function(item) {
-        rendered = rendered + "<li>The word <b>" + item.word + "</b> is defined as <b>" + item.definition + "</b></li>";
-      });
+      if(data.length) {
+        data.forEach(function(item) {
+          rendered = rendered + "<li>The word <b>" + item.word + "</b> is defined as <b>" + item.definition + "</b></li>";
+        });
+      }
       rendered = rendered + "</ul>";
 
       $('#displayOutput').html(rendered);
@@ -19,7 +21,7 @@ $(document).ready(function() {
   $('#add-word').submit(function(e) {
     e.preventDefault();
     $.ajax({
-      url: '../example',
+      url: '/words',
       type: 'PUT',
       data: $(this).serialize(),
       success: function(data) {

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -6,9 +6,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="../static/styles/style.css">
+    <link rel="stylesheet" href="static/styles/style.css">
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js" type="text/javascript"></script>
-    <script src="../static/main.js" type="text/javascript"></script>
+    <script src="static/main.js" type="text/javascript"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This makes the paths all relative to the directory they are in and also brings the paths in line with the other examples:
 - `GET /words` gets a JSON-formatted list of words
 - `PUT /words` expects a URL-encoded (actually Jquery serialized) data set with keys: words, definition
 - anything else will return the HTML template